### PR TITLE
Parsedownの拡張クラスを作成し、h2・h3・codeblock内にCSSとpタグをつける

### DIFF
--- a/app/controllers/PublicArticleController.php
+++ b/app/controllers/PublicArticleController.php
@@ -31,7 +31,7 @@ class PublicArticleController
       return;
     }
 
-    $article['content_html'] = $this->parsedown->text($article['content']); 
+    $article['content_html'] = $this->parsedown->text($article['content']);
 
     include $_SERVER['DOCUMENT_ROOT'] . '/pj_homepage/app/views/home/article.php';
   }

--- a/app/libs/CustomParsedown.php
+++ b/app/libs/CustomParsedown.php
@@ -8,10 +8,122 @@ class CustomParsedown extends Parsedown
     // 親のメソッドでマークダウンをHTMLに変換
     $html = parent::text($text);
 
-    // <h2>～<h6>タグから次のh系タグまでのコンテンツを囲む
+    echo $html;
+    $html = $this->wrapParagraphs($html);
+    $html = $this->wrapWithDiv($html);
+    $html = $this->addClassToH2($html);
+
+    return $html;
+  }
+
+  /**
+   * <h2>～<h6>タグから次のh系タグまでのコンテンツを囲む
+   *
+   * @param string $html HTMLに変換された文字列
+   * @return void
+   */
+  private function wrapWithDiv($html)
+  {
     $pattern = '/(<h[2-6][^>]*>.*?<\/h[2-6]>)(.*?)(?=<h[2-6]|$)/s';  // h2～h6タグが基準
     $replacement = '<div class="article__content">$1$2</div>';
-
     return preg_replace($pattern, $replacement, $html);
+  }
+
+  /**
+   * h2タグにクラスをつける
+   *
+   * @param string $html HTMLに変換された文字列
+   * @return void
+   */
+  private function addClassToH2($html)
+  {
+    $pattern = '/(<h2)([^>]*>)/';
+    $replacement = '$1 class="underline-with-background"$2';
+    return preg_replace($pattern, $replacement, $html);
+  }
+
+  private function wrapParagraphs($html)
+  {
+    // 文の中身をマッチさせる
+    $html = preg_replace_callback('/([^\n\r]+(\n|\r\n)?)/', function ($matches) {
+      $line = trim($matches[0]);
+
+      // 空行の場合は何も返さない
+      if ($line === '') {
+        return '';
+      }
+
+      // 他のHTMLタグがある場合はそのまま返す
+      if ($this->hasOtherTags($line)) {
+        return $line . "\n";
+      }
+
+      // 既に<p></p>で囲まれているときはそのまま返す
+      if ($this->isWrappedInPTags($line)) {
+        return $line . "\n";
+      }
+
+      // <p>タグが一切ついていないときは追加
+      if (!$this->hasPTags($line)) {
+        return '<p>' . trim($matches[1]) . '</p>' . "\n";
+      }
+
+      // <p>のみないときは追加
+      if ($this->hasClosingPTag($line)) {
+        return '<p>' . trim($matches[1]);
+      }
+      
+      // </p>のみないときに追加
+      if (!$this->hasClosingPTag($line)){
+        return trim($matches[1]) . '</p>' . "\n";
+      }
+
+      return $line;
+    }, $html);
+
+    return $html;
+  }
+
+
+  /**
+   * 先頭に<p>タグ以外のタグがあるか判定
+   *
+   * @param string $line 
+   * @return boolean
+   */
+  private function hasOtherTags($line) {
+    // 先頭に<p>
+    return substr($line, 0, 1) === '<' && substr($line, 1, 1) !== 'p';
+  }
+
+  /**
+   * <p>タグで囲まれているか判定
+   *
+   * @param string $line
+   * @return boolean
+   */
+  private function isWrappedInPTags($line)
+  {
+    return preg_match('/^<p>.*<\/p>$/s', $line);
+  }
+
+  /**
+   * <p>と</p>の両方があるか判定
+   *
+   * @param string $line
+   * @return boolean
+   */
+  private function hasPTags($line) {
+    return strpos($line, '<p>') !== false || strpos($line, '</p>') !== false;
+  }
+
+  /**
+   * </p>で終わっているかを判定
+   *
+   * @param string $line
+   * @return boolean
+   */
+  private function hasClosingPTag($line) {
+    return substr($line, -4) === '</p>';
   }
 }

--- a/app/libs/CustomParsedown.php
+++ b/app/libs/CustomParsedown.php
@@ -12,6 +12,7 @@ class CustomParsedown extends Parsedown
     $html = $this->wrapParagraphs($html);
     $html = $this->wrapWithDiv($html);
     $html = $this->addClassToH2($html);
+    $html = $this->addClassToH3($html);
 
     return $html;
   }
@@ -39,6 +40,19 @@ class CustomParsedown extends Parsedown
   {
     $pattern = '/(<h2)([^>]*>)/';
     $replacement = '$1 class="underline-with-background"$2';
+    return preg_replace($pattern, $replacement, $html);
+  }
+
+  /**
+   * h3タグにクラスをつける
+   *
+   * @param string $html HTMLに変換された文字列
+   * @return void
+   */
+  private function addClassToH3($html)
+  {
+    $pattern = '/(<h3)([^>]*>)/';
+    $replacement = '$1 class="orange-underline-heading"$2';
     return preg_replace($pattern, $replacement, $html);
   }
 

--- a/app/views/home/article.php
+++ b/app/views/home/article.php
@@ -24,46 +24,7 @@
               <img src="/pj_homepage/assets/image/img_ranking1.jpg">
             </div>
           </div>
-
           <?= $article['content_html'] ?>
-
-          <!-- <div class="article__content">
-            <h2 class="underline-with-background">PixJSとは</h2>
-            <p>PixiJSとは、Javascriptで使うことができます。というような説明の文章を入れる部分です。</p>
-            <p>参考リンクがある場合は、<a href="#">ここを</a>クリックしてください。</p>
-          </div>
-
-          <div class="article__content">
-            <h3 class="orange-underline-heading">PixiJSの歴史</h3>
-            <ul>
-              <li>2002年</li>
-              <li>2010年</li>
-              <li>2022年</li>
-            </ul>
-            <p>こんな感じで、リスト形式にも並べることができます</p>
-            <p>コードブロックの機能を追加しました。</p>
-            <div class="code-block">
-              <pre class="line-numbers" data-copy="true"><code class="language-javascript">
-function greet() {
-  console.log('Hello, world!');
-}
-              </code></pre>
-            </div>
-            <p>コードを表示することができますし、コピーもできます</p>
-          </div>
-
-          <div class="article__content">
-            <h2 class="underline-with-background">まとめ</h2>
-            <p>こんな感じで記事を増やしていこう</p>
-            <p>やること残り</p>
-            <ul>
-              <li>コードブロックの作成</li>
-              <li>Shareボタン</li>
-              <li>カテゴリの表示</li>
-              <li>前の記事と次の記事</li>
-              <li>レスポンス時の見た目調整</li>
-            </ul>
-          </div> -->
         </div>
 
       </article>


### PR DESCRIPTION
h2・h3・codeタグの中にCSSのクラスを自動的につけるようにした
pタグの位置が通常のParsedownでは文ごとになっていないため、文ごとにpタグが配置されるように修正した
コードブロック内にpタグが配置されないようにした

よって、記事がCSSのクラスをつけた状態のHTMLファイルを受け取るようにできた