### PR TITLE
Fix: 記事画像のファイル名に image ディレクトリが含まれてしまう問題を修正

### DIFF
--- a/app/controllers/admin/CreateArticleController.php
+++ b/app/controllers/admin/CreateArticleController.php
@@ -112,7 +112,7 @@ class CreateArticleController extends BaseArticleController
       }
       // 記事画像のリネーム
       foreach ($imageData as $index => $image) {
-        $newImageFileName = 'image_' . $articleId . ($index != null ? '_' . $index : '') . '.' . pathinfo($file['name'], PATHINFO_EXTENSION);
+        $newImageFileName = '/image_' . $articleId . ($index != null ? '_' . $index : '') . '.' . pathinfo($file['name'], PATHINFO_EXTENSION);
         $newImageFilePath = $this->config->get('assets')['articles'] . $newImageFileName;
 
         if (rename($image['tmp_path'], $newImageFilePath)) {


### PR DESCRIPTION
## 概要
新規記事作成時に画像ファイルのURL生成処理で、`image` ディレクトリがファイル名の一部として扱われてしまっていた不具合を修正しました。

## 修正内容
- 画像のファイル名 `$newImageFileName` の先頭に `/` を付与し、 `image` をパスの一部（ディレクトリ）として扱うように修正
